### PR TITLE
OpenLDAP version 2.4.46

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,10 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y ldap-utils wget gcc make libdb
 apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Get openldap source to compile check password
-RUN wget -O /root/openldap-2.4.44.tgz https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.4.44.tgz && \
+RUN wget -O /root/openldap-2.4.46.tgz https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.4.46.tgz && \
 	cd /root && \
-	tar -zxvf openldap-2.4.44.tgz &&  \
-	cd openldap-2.4.44 && ./configure && \
+	tar -zxvf openldap-2.4.46.tgz &&  \
+	cd openldap-2.4.46 && ./configure && \
 	make depend
 
 RUN wget -O /root/cracklib-2.9.6.tar.gz https://github.com/cracklib/cracklib/releases/download/cracklib-2.9.6/cracklib-2.9.6.tar.gz && \
@@ -58,7 +58,7 @@ RUN wget -O /root/cracklib-words-2.9.6.gz https://github.com/cracklib/cracklib/r
 RUN wget -O /root/openldap-ppolicy-check-password-1.1.tar.gz https://github.com/ltb-project/openldap-ppolicy-check-password/archive/v1.1.tar.gz && \
 	cd /root && gunzip openldap-ppolicy-check-password-1.1.tar.gz && tar -xvf openldap-ppolicy-check-password-1.1.tar && \
 	cd openldap-ppolicy-check-password-1.1 && \
-	make install  CONFIG="/etc/ldap/check_password.conf" LDAP_INC="-I/root/openldap-2.4.44/include/ -I/root/openldap-2.4.44/servers/slapd" \
+	make install  CONFIG="/etc/ldap/check_password.conf" LDAP_INC="-I/root/openldap-2.4.46/include/ -I/root/openldap-2.4.46/servers/slapd" \
 	CRACKLIB="/lib/cracklib/" CRACKLIB_LIB="/usr/lib/libcrack.so.2" LIBDIR="/usr/lib/ldap/"
 	
 # Cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM dinkel/openldap:latest
+FROM timhawes/openldap:latest
 
-MAINTAINER Darren Jackson, <darren.a.jackson>
+#MAINTAINER Darren Jackson, <darren.a.jackson>
 
 # Replicate all default environment variables from the base image and customize the needed one's. 
 # This is to be able to use a custom entrypoint and perform all needed settings

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fatimajavaid/open-ldap:latest
+FROM fatimajavaid/openldap:2.4.46
 
 #MAINTAINER Darren Jackson, <darren.a.jackson>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y ldap-utils wget gcc make libdb
 apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Get openldap source to compile check password
-RUN wget -O /root/openldap-2.4.40.tgz https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.4.44.tgz && \
+RUN wget -O /root/openldap-2.4.44.tgz https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.4.44.tgz && \
 	cd /root && \
 	tar -zxvf openldap-2.4.44.tgz &&  \
 	cd openldap-2.4.44 && ./configure && \
@@ -58,7 +58,7 @@ RUN wget -O /root/cracklib-words-2.9.6.gz https://github.com/cracklib/cracklib/r
 RUN wget -O /root/openldap-ppolicy-check-password-1.1.tar.gz https://github.com/ltb-project/openldap-ppolicy-check-password/archive/v1.1.tar.gz && \
 	cd /root && gunzip openldap-ppolicy-check-password-1.1.tar.gz && tar -xvf openldap-ppolicy-check-password-1.1.tar && \
 	cd openldap-ppolicy-check-password-1.1 && \
-	make install  CONFIG="/etc/ldap/check_password.conf" LDAP_INC="-I/root/openldap-2.4.40/include/ -I/root/openldap-2.4.40/servers/slapd" \
+	make install  CONFIG="/etc/ldap/check_password.conf" LDAP_INC="-I/root/openldap-2.4.44/include/ -I/root/openldap-2.4.44/servers/slapd" \
 	CRACKLIB="/lib/cracklib/" CRACKLIB_LIB="/usr/lib/libcrack.so.2" LIBDIR="/usr/lib/ldap/"
 
 # Cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,10 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y ldap-utils wget gcc make libdb
 apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Get openldap source to compile check password
-RUN wget -O /root/openldap-2.4.40.tgz https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.4.40.tgz && \
+RUN wget -O /root/openldap-2.4.40.tgz https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.4.44.tgz && \
 	cd /root && \
-	tar -zxvf openldap-2.4.40.tgz &&  \
-	cd openldap-2.4.40 && ./configure && \
+	tar -zxvf openldap-2.4.44.tgz &&  \
+	cd openldap-2.4.44 && ./configure && \
 	make depend
 
 RUN wget -O /root/cracklib-2.9.6.tar.gz https://github.com/cracklib/cracklib/releases/download/cracklib-2.9.6/cracklib-2.9.6.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dinkel/openldap:2.4.40
+FROM dinkel/openldap:latest
 
 MAINTAINER Darren Jackson, <darren.a.jackson>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN wget -O /root/openldap-ppolicy-check-password-1.1.tar.gz https://github.com/
 	cd openldap-ppolicy-check-password-1.1 && \
 	make install  CONFIG="/etc/ldap/check_password.conf" LDAP_INC="-I/root/openldap-2.4.44/include/ -I/root/openldap-2.4.44/servers/slapd" \
 	CRACKLIB="/lib/cracklib/" CRACKLIB_LIB="/usr/lib/libcrack.so.2" LIBDIR="/usr/lib/ldap/"
-
+	
 # Cleanup
 RUN DEBIAN_FRONTEND=noninteractive apt-get remove -y wget gcc libdb-dev make && rm -rf /root/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM timhawes/openldap:latest
+FROM fatimajavaid/open-ldap:latest
 
 #MAINTAINER Darren Jackson, <darren.a.jackson>
 


### PR DESCRIPTION
Ldap version 2.4.40 is being used. To update this, created a new base image for ldap to use latest version 2.4.46. (Image can be found at: https://hub.docker.com/r/fatimajavaid/openldap/tags/)

NB. The latest OpenLDAP version is 2.4.46. Currently, there are no debian packages compatible for the latest ldap version on debian:stretch. Therefore, debian:stretch-backports has been used to create the base image. Stretch-backports has the stability of stretch version and latest features of the newer versions (buster and sid). Moreover, it has libraries that are updated. (Dockerfile for base image can be found at: https://github.com/Fatima-Javaid/docker-openldap)