### PR TITLE
Remediate high vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,25 @@ apt-get update && \
 DEBIAN_FRONTEND=noninteractive apt-get install -y ldap-utils wget gcc make libdb-dev && \
 apt-get clean && rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update && \
+    DEBIAN_FRONTEND=non-interactive apt-get install -y bash=4.3-11+deb8u1 \
+    libc-bin=2.19-18+deb8u10 \
+    libgnutls-deb0-28=3.3.8-6+deb8u7 \
+    libhogweed2=2.7.1-5+deb8u2 \
+    libncurses5=5.9+20140913-1+deb8u3 \
+    libncursesw5=5.9+20140913-1+deb8u3 \
+    libnettle4=2.7.1-5+deb8u2 \
+    libsystemd0=215-17+deb8u9 \
+    libtinfo5=5.9+20140913-1+deb8u3 \
+    libudev1=215-17+deb8u9 \
+    multiarch-support=2.19-18+deb8u10 \
+    ncurses-base=5.9+20140913-1+deb8u3 \
+    ncurses-bin=5.9+20140913-1+deb8u3 \
+    perl=5.20.2-3+deb8u12 \
+    systemd=215-17+deb8u9 \
+    systemd-sysv=215-17+deb8u9 && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Get openldap source to compile check password
 RUN wget -O /root/openldap-2.4.40.tgz https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.4.40.tgz && \
 	cd /root && \


### PR DESCRIPTION
There are 70 high vulnerabilities on the current accenture/adop-ldap:latest image.
![image](https://user-images.githubusercontent.com/20415900/51892780-e4824d00-23dd-11e9-87f1-102339713512.png)

After upgrading highly vulnerable packages, there are only 12 high vulnerabilities left - all related to linux-libc-dev-3.16.59-1 that doesn't have a fix for now.
![image](https://user-images.githubusercontent.com/20415900/51892808-f9f77700-23dd-11e9-841b-53ecfc2ac55a.png)
![image](https://user-images.githubusercontent.com/20415900/51892850-185d7280-23de-11e9-84fa-66b98d9f73a2.png)